### PR TITLE
bugfix - typeError takes 0 positional arguments but 3 were given

### DIFF
--- a/gcp_log/_formatter.py
+++ b/gcp_log/_formatter.py
@@ -13,34 +13,34 @@ except ImportError:
     orjson = None
 
 
-T = TypeVar("T")
+T = TypeVar('T')
 
 # https://docs.python.org/3/library/logging.html#logrecord-attributes
 RESERVED_ATTRS = frozenset(
     {
-        "args",
-        "asctime",
-        "color_message",
-        "created",
-        "exc_info",
-        "exc_text",
-        "filename",
-        "funcName",
-        "levelname",
-        "levelno",
-        "lineno",
-        "message",
-        "module",
-        "msecs",
-        "msg",
-        "name",
-        "pathname",
-        "process",
-        "processName",
-        "relativeCreated",
-        "stack_info",
-        "thread",
-        "threadName",
+        'args',
+        'asctime',
+        'color_message',
+        'created',
+        'exc_info',
+        'exc_text',
+        'filename',
+        'funcName',
+        'levelname',
+        'levelno',
+        'lineno',
+        'message',
+        'module',
+        'msecs',
+        'msg',
+        'name',
+        'pathname',
+        'process',
+        'processName',
+        'relativeCreated',
+        'stack_info',
+        'thread',
+        'threadName',
     }
 )
 
@@ -48,7 +48,7 @@ RESERVED_ATTRS = frozenset(
 def ensure_imported(target: T | str) -> T:
     if not isinstance(target, str):
         return target
-    path, function = target.rsplit(".", maxsplit=1)
+    path, function = target.rsplit('.', maxsplit=1)
     module = import_module(path)
     return getattr(module, function)
 
@@ -65,7 +65,7 @@ class Formatter(logging.Formatter):
         self,
         fmt: str = None,
         datefmt: str = None,
-        style: str = "%",
+        style: str = '%',
         validate: bool = True,
         default: Callable[[object], object] | str = str,
     ) -> None:
@@ -77,25 +77,25 @@ class Formatter(logging.Formatter):
         created_at = datetime.fromtimestamp(record.created).astimezone(timezone.utc)
 
         result: dict[str, object] = {
-            "message": record.message,
-            "severity": record.levelname.upper(),
-            "timestamp": f"{created_at.isoformat()}Z",
-            "logging.googleapis.com/sourceLocation": {
-                "file": record.pathname,
-                "line": record.lineno,
-                "function": record.funcName,
+            'message': record.message,
+            'severity': record.levelname.upper(),
+            'timestamp': f'{created_at.isoformat()}Z',
+            'logging.googleapis.com/sourceLocation': {
+                'file': record.pathname,
+                'line': record.lineno,
+                'function': record.funcName,
             },
         }
 
         if record.exc_info:
-            result["exc_info"] = self.formatException(record.exc_info)
+            result['exc_info'] = self.formatException(record.exc_info)
         elif record.exc_text:
-            result["exc_info"] = record.exc_text
+            result['exc_info'] = record.exc_text
         if record.stack_info:
-            result["stack_info"] = record.stack_info
+            result['stack_info'] = record.stack_info
 
         for key, value in record.__dict__.items():
-            if key.startswith("_"):
+            if key.startswith('_'):
                 continue
             if key in RESERVED_ATTRS:
                 continue
@@ -107,5 +107,5 @@ class Formatter(logging.Formatter):
             result,
             default=self.default,
             allow_nan=False,
-            separators=(",", ":"),
+            separators=(',', ':'),
         )

--- a/gcp_log/_formatter.py
+++ b/gcp_log/_formatter.py
@@ -60,8 +60,12 @@ class Formatter(logging.Formatter):
 
     def __init__(
         self,
+        fmt: str = None,
+        datefmt: str = None,
+        style: str = '%',
         default: Callable[[object], object] | str = str,
     ) -> None:
+        super().__init__(fmt, datefmt, style)
         self.default = ensure_imported(default)
 
     def format(self, record: logging.LogRecord) -> str:

--- a/gcp_log/_formatter.py
+++ b/gcp_log/_formatter.py
@@ -16,34 +16,31 @@ except ImportError:
 T = TypeVar('T')
 
 # https://docs.python.org/3/library/logging.html#logrecord-attributes
-RESERVED_ATTRS = frozenset(
-    {
-        'args',
-        'asctime',
-        'color_message',
-        'created',
-        'exc_info',
-        'exc_text',
-        'filename',
-        'funcName',
-        'levelname',
-        'levelno',
-        'lineno',
-        'message',
-        'module',
-        'msecs',
-        'msg',
-        'name',
-        'pathname',
-        'process',
-        'processName',
-        'relativeCreated',
-        'stack_info',
-        'thread',
-        'threadName',
-    }
-)
-
+RESERVED_ATTRS = frozenset({
+    'args',
+    'asctime',
+    'color_message',
+    'created',
+    'exc_info',
+    'exc_text',
+    'filename',
+    'funcName',
+    'levelname',
+    'levelno',
+    'lineno',
+    'message',
+    'module',
+    'msecs',
+    'msg',
+    'name',
+    'pathname',
+    'process',
+    'processName',
+    'relativeCreated',
+    'stack_info',
+    'thread',
+    'threadName',
+})
 
 def ensure_imported(target: T | str) -> T:
     if not isinstance(target, str):
@@ -84,7 +81,7 @@ class Formatter(logging.Formatter):
                 'file': record.pathname,
                 'line': record.lineno,
                 'function': record.funcName,
-            },
+            }
         }
 
         if record.exc_info:


### PR DESCRIPTION
I get error when trying to use the lib for logging I get '_typeError takes 0 positional arguments but 3 were given_'

After checking it seems python is expecting parameters that needed by default on formatter class need fmt , datefmt, style, and  validate.

functional tests work and the unit test coverage was 75%